### PR TITLE
locking: handle concurrent flushes

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -172,6 +172,7 @@ func (lru *LRU) Iter(keys chan Key, values chan Value) {
 func (lru *LRU) Flush() {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
+
 	if lru.removalFunc != nil {
 		for e := lru.list.Front(); e != nil; e = e.Next() {
 			n := e.Value.(*entry)
@@ -187,6 +188,9 @@ func (lru *LRU) FlushExpired() {
 	if lru.removalFunc == nil || lru.ttl == 0 {
 		return
 	}
+
+	lru.mu.Lock()
+	defer lru.mu.Unlock()
 
 	cutoff := time.Now().Add(-1 * lru.ttl)
 	for e := lru.list.Front(); e != nil; e = e.Next() {

--- a/lru.go
+++ b/lru.go
@@ -193,7 +193,10 @@ func (lru *LRU) FlushExpired() {
 	defer lru.mu.Unlock()
 
 	cutoff := time.Now().Add(-1 * lru.ttl)
-	for e := lru.list.Front(); e != nil; e = e.Next() {
+	var next *list.Element
+	for e := lru.list.Front(); e != nil; e = next {
+		// get the next before removal below which causes Next to return nil
+		next = e.Next()
 		n := e.Value.(*entry)
 		if cutoff.After(n.ts) {
 			lru.list.Remove(e)

--- a/lru_counter.go
+++ b/lru_counter.go
@@ -73,12 +73,16 @@ func (c *LRUCounter) Capacity() int {
 
 // Flush all entries
 func (c *LRUCounter) Flush() {
+	c.Lock()
 	c.lru.Flush()
+	c.Unlock()
 }
 
 // FlushExpired flushes entries that are expired based on the configured TTL
 func (c *LRUCounter) FlushExpired() {
+	c.Lock()
 	c.lru.FlushExpired()
+	c.Unlock()
 }
 
 // Incr the key by value (goroutine safe)


### PR DESCRIPTION
This better locks around concurrent flush calls.
