### PR TITLE
Exposing Iter() method on LRUCounter

### DIFF
--- a/lru_counter.go
+++ b/lru_counter.go
@@ -71,6 +71,10 @@ func (c *LRUCounter) Capacity() int {
 	return c.lru.Capacity()
 }
 
+func (c *LRUCounter) Iter(keys chan Key, values chan Value) {
+	c.lru.Iter(keys, values)
+}
+
 // Flush all entries
 func (c *LRUCounter) Flush() {
 	c.lru.Flush()


### PR DESCRIPTION
I was using the library when noticed that Iter() method is defined for LRU but not exposed for LRUCounter as Len(), Set() and Get() are. This is a small change to fix that.